### PR TITLE
Improve SWR RSC preloading

### DIFF
--- a/features/message/components/message-thread.tsx
+++ b/features/message/components/message-thread.tsx
@@ -9,29 +9,22 @@ import { getCurrentUser, getUsers } from '@/features/user/user-queries'
 import { MessageList } from './message-list'
 
 export async function MessageThread({ channelId }: { channelId: string }) {
+  const userData = preload(userKeys.all, getUsers)
   const user = await getCurrentUser()
-  const [messages, users, lastReadAt] = await Promise.all([
+  const messageData = preload(messageKeys.channel(channelId), () =>
     getMessagesForUser(channelId, user.id),
-    getUsers(),
-    getLastReadAt(channelId, user.id),
-  ])
-  const messageData = preload(
-    messageKeys.channel(channelId),
-    async () => messages,
   )
-  const userData = preload(userKeys.all, async () => users)
+  const lastReadAt = await getLastReadAt(channelId, user.id)
 
   return (
-    <SWRConfig value={{ cacheData: messageData }}>
-      <SWRConfig value={{ cacheData: userData }}>
-        <MessageList
-          channelId={channelId}
-          currentUserId={user.id}
-          key={channelId}
-          lastReadAt={lastReadAt}
-        />
-        <MarkChannelRead channelId={channelId} />
-      </SWRConfig>
+    <SWRConfig value={{ cacheData: { ...messageData, ...userData } }}>
+      <MessageList
+        channelId={channelId}
+        currentUserId={user.id}
+        key={channelId}
+        lastReadAt={lastReadAt}
+      />
+      <MarkChannelRead channelId={channelId} />
     </SWRConfig>
   )
 }

--- a/features/user/components/user-switcher.tsx
+++ b/features/user/components/user-switcher.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils'
 
 export function UserSwitcher({ currentUserId }: { currentUserId: string }) {
   const router = useRouter()
-  const { mutate } = useSWRConfig()
+  const { unload } = useSWRConfig()
   const [isPending, startTransition] = useTransition()
   const nextUserId = currentUserId === 'ada' ? 'grace' : 'ada'
 
@@ -23,7 +23,7 @@ export function UserSwitcher({ currentUserId }: { currentUserId: string }) {
       onClick={() => {
         startTransition(async () => {
           const destination = await switchUser(nextUserId)
-          await mutate(() => true, undefined, { revalidate: false })
+          unload({ revalidate: false })
           router.push(destination as Route)
         })
       }}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-dom": "19.2.4",
     "server-only": "^0.0.1",
     "sonner": "^2.0.7",
-    "swr": "2.5.0-beta.0",
+    "swr": "2.5.0-beta.1",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       swr:
-        specifier: 2.5.0-beta.0
-        version: 2.5.0-beta.0(react@19.2.4)
+        specifier: 2.5.0-beta.1
+        version: 2.5.0-beta.1(react@19.2.4)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -1634,8 +1634,8 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  swr@2.5.0-beta.0:
-    resolution: {integrity: sha512-Bvts8Jl7pU/aoPwMapwY4Zq/KLU5XgKnbyzI6Uj1GqBuGHgqXemboHYao/QB5cJB9tQ/5hotzyoE0Gpk3miUBg==}
+  swr@2.5.0-beta.1:
+    resolution: {integrity: sha512-wXUkEElUHL0it5lmjMVuwua49mwgMILkonY9QvdlP4d/ywM8UhTtqX8aBTTHUk79OJqfnLjFosIiK+KsSFco4A==}
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -3047,7 +3047,7 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.4
 
-  swr@2.5.0-beta.0(react@19.2.4):
+  swr@2.5.0-beta.1(react@19.2.4):
     dependencies:
       dequal: 2.0.3
       react: 19.2.4


### PR DESCRIPTION
## Summary

- upgrade SWR to 2.5.0-beta.1
- start message and user preloads before the server component waits for unrelated data
- merge the message and user cache data into one scoped SWR provider
- use SWR's new unload API when switching users so in-flight requests cannot refill the previous user's cache

## Verification

- `pnpm typecheck`
- `pnpm exec prettier --check features/message/components/message-thread.tsx features/user/components/user-switcher.tsx package.json`
- `git diff --check`
