### PR TITLE
Rename runtime prefetching to optimizing prefetching

### DIFF
--- a/.agents/skills/nextjs-app-architecture/references/pages-suspense.md
+++ b/.agents/skills/nextjs-app-architecture/references/pages-suspense.md
@@ -218,11 +218,11 @@ Fixes:
 
 To audit CLS, use React DevTools' Suspense panel to pin each boundary in its loading state and check vertical positions.
 
-## Runtime prefetch for high-value routes
+## Optimizing prefetching for high-value routes
 
 With `cacheComponents` + [`partialPrefetching`](https://preview.nextjs.org/docs/app/api-reference/config/next-config-js/partialPrefetching) enabled, a visible `<Link>` prefetches the destination's shared [App Shell](https://preview.nextjs.org/docs/app/glossary#app-shell) — enough to commit navigation instantly, with link-specific content streaming after. The default (`'auto'`) already does this; don't write `prefetch = 'auto'`.
 
-Use `<Link prefetch={true}>` on high-value links to also resolve the destination's per-link runtime data (`params`, `searchParams`, the full URL) before the click. Each such link can wake the server for a runtime prerender, so reserve it for routes users predictably visit next. See [runtime prefetching](https://preview.nextjs.org/docs/app/guides/runtime-prefetching).
+Use `<Link prefetch={true}>` on high-value links to also resolve the destination's per-link data (`params`, `searchParams`, the full URL) at prefetch time. Each such link can wake the server for a prerender, so reserve it for routes users predictably visit next. See [Optimizing prefetching](https://preview.nextjs.org/docs/app/guides/optimizing-prefetching).
 
 Can't enable `partialPrefetching` app-wide yet? Opt in per route with `export const prefetch = 'partial'` on the destination, then drop the per-route exports once the global flag is on — see [Adopting Partial Prefetching](https://preview.nextjs.org/docs/app/guides/adopting-partial-prefetching) for the incremental path and [prefetch config](https://preview.nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/prefetch) for the options. To validate navigation feels instant, see the [`instant` config](https://preview.nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/instant) and [Instant Navigation guide](https://preview.nextjs.org/docs/app/guides/instant-navigation).
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -185,14 +185,14 @@ const messages = [
     'm-8',
     'team-frontend',
     'ada',
-    'The hover case is separate. The costly path here is full runtime prefetch on every visible link.',
+    'The hover case is separate. The costly path here is a full prefetch on every visible link.',
     '2026-07-29T13:03:00.000Z',
   ],
   [
     'm-9',
     'team-frontend',
     'grace',
-    'I linked the runtime prefetching guide and kept the warning short. No need to copy the docs into the skill.',
+    'I linked the optimizing prefetching guide and kept the warning short. No need to copy the docs into the skill.',
     '2026-07-29T13:06:00.000Z',
   ],
   [


### PR DESCRIPTION
`/docs/app/guides/runtime-prefetching` now redirects to [`/docs/app/guides/optimizing-prefetching`](https://nextjs.org/docs/app/guides/optimizing-prefetching), and that guide no longer contains the phrase "runtime prefetch" anywhere. Its sections are "Resolve URL data at prefetch time", "Include session data in the shell", and "Extract and pass `use cache: private`".

- `.agents/skills/.../pages-suspense.md`: heading becomes `## Optimizing prefetching for high-value routes`, "per-link runtime data ... before the click" becomes "... at prefetch time", "a runtime prerender" becomes "a prerender", and the link points at the new slug.
- `prisma/seed.ts`: two seeded chat messages referred to "full runtime prefetch" and "the runtime prefetching guide". Reworded to "a full prefetch" and "the optimizing prefetching guide".

Docs and seed copy only. This repo has no `prefetch = 'allow-runtime'` usage, so nothing behavioral is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)